### PR TITLE
fixes so build are independent of gigaspaces

### DIFF
--- a/cloudify/.gitignore
+++ b/cloudify/.gitignore
@@ -1,0 +1,4 @@
+target
+releases
+tmp
+xap.files.tmp.dir

--- a/cloudify/build.xml
+++ b/cloudify/build.xml
@@ -12,13 +12,10 @@
 
 <project name="Cloudify-Assembly" default="usage" basedir=".">
 	
-	<condition property="build.repository.path" value="\\tarzan\builds">
-		<os family="windows" />
-	</condition>
-
-	<condition property="build.repository.path" value="/export/builds">
-		<os family="unix" />
-	</condition>
+	<available file="\\tarzan\builds" property="build.repository.path" value="\\tarzan\builds"/>
+	<available file="/export/builds" property="build.repository.path" value="/export/builds"/>
+	<!-- by default it is downloaded to here -->
+	<property name="build.repository.path" value="target/build-repository"/>
 
 	<condition property="mvn.executable" value="mvn.bat">
             <os family="windows" />
@@ -39,7 +36,6 @@
 	<property name="xap.zip.full.path" value="${build.repository.path}/${gs.version}/build_${gs.build.number}/xap-premium/1.5/${xap.zip.name}" />
 	<property name="cloudify.installation.dir" value="gigaspaces-cloudify-${cloudify.version}-${cloudify.milestone}" />
 	<property name="cloudify.zip.name" value="${cloudify.installation.dir}-b${cloudify.build.number}.zip" />
-	<property name="xap.zip.full.path" value="${build.repository.path}/cloudify/${cloudify.version}/build_${cloudify.build.number}/product/${xap.zip.name}" />
 	<property name="CLOUDIFY" value="Cloudify" />
 	<property name="cloudify" value="cloudify" />
 	<property name="gs.runtime.jar" value="gs-runtime.jar" />
@@ -539,6 +535,9 @@
 		
 		<available file="${xap.files.tmp.dir}/${xap.zip.name}" property="appropriate.xap.zip.present"/>
 		<ant target="download.zip" />
+
+		<!-- part of the build assumes this is available (perhaps it shouldn't but for now this fixes failures) -->
+		<copy file="${xap.files.tmp.dir}/${xap.zip.name}" tofile="${xap.zip.full.path}"/>
 			
 		<unzip src="${xap.files.tmp.dir}/${xap.zip.name}" dest="${tmp.dir}" />	
 		<move file="${tmp.dir}/${xap.installation.dir}" tofile="${tmp.dir}/${cloudify.installation.dir}" />

--- a/esc/src/test/java/org/cloudifysource/esc/byon/ParseByonCloudNodesTest.java
+++ b/esc/src/test/java/org/cloudifysource/esc/byon/ParseByonCloudNodesTest.java
@@ -80,10 +80,8 @@ public class ParseByonCloudNodesTest {
 			// id, ip
 			expectedNodes.add(new CustomNodeImpl(PROVIDER, "byon-test02", "0.0.0.2", null, null, "byon-test02"));
 			// idPrefix, ipList
-			//expectedNodes.add(new CustomNodeImpl(PROVIDER, "byon-test11", "0.0.0.3", null, null, "byon-test11"));
-			//expectedNodes.add(new CustomNodeImpl(PROVIDER, "byon-test12", "0.0.0.4", null, null, "byon-test12"));
-			expectedNodes.add(new CustomNodeImpl(PROVIDER, "byon-test11", "192.168.9.59", null, null, "byon-test11"));
-			expectedNodes.add(new CustomNodeImpl(PROVIDER, "byon-test12", "192.168.9.60", null, null, "byon-test12"));
+			expectedNodes.add(new CustomNodeImpl(PROVIDER, "byon-test11", "0.0.0.3", null, null, "byon-test11"));
+			expectedNodes.add(new CustomNodeImpl(PROVIDER, "byon-test12", "0.0.0.4", null, null, "byon-test12"));
 			expectedNodes.add(new CustomNodeImpl(PROVIDER, "byon-test13", "0.0.0.5", null, null, "byon-test13"));
 			// id (template), ipList
 			expectedNodes.add(new CustomNodeImpl(PROVIDER, "byon-test21", "0.0.0.6", null, null, "byon-test21"));

--- a/esc/testResources/byon/testbyon-cloud.groovy
+++ b/esc/testResources/byon/testbyon-cloud.groovy
@@ -39,6 +39,7 @@ cloud {
 		// Mandatory. Files from the local directory will be copied to this directory on the remote machine. 
 		remoteDirectory "/tmp/gs-files"
 		// Mandatory. The HTTP/S URL where cloudify can be downloaded from by newly started machines.
+		// FIXME this should point to either a public maven repo or latest release build by default
 		cloudifyUrl "http://pc-lab25:8087/publish/gigaspaces.zip"
 		// Mandatory. The prefix for new machines started for servies.
 		machineNamePrefix "cloudify_agent_"
@@ -84,7 +85,7 @@ cloud {
 										]),
 										([
 											"id" : "byon-test1",
-											"ip" : "pc-lab39,pc-lab40,0.0.0.5"
+											"ip" : "0.0.0.3,0.0.0.4,0.0.0.5"
 										]),
 										([
 											"id" : "byon-test2{0}",


### PR DESCRIPTION
both ant build and maven test case had hard-coded gigaspaces internal subnet dependencies;
with the changes attached it now builds for me.
