### PR TITLE
Fix .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk6
-before_script: "mvn install -f ./cloudify/pom.xml --quiet -DskipTests=true"
+  - openjdk6
+install: "mvn install -f ./cloudify/pom.xml --quiet -DskipTests=true"
 script: "mvn test -f ./cloudify/pom.xml"
 


### PR DESCRIPTION
Oracle JDK 6 is not provided. Please only use what is listed in the docs.
Instead of using before_script to install dependencies, override `install`.
