### PR TITLE
CLOUDIFY-2026 : Ability to provide user auth info for file download.

### DIFF
--- a/dsl/src/main/java/org/cloudifysource/dsl/internal/tools/download/ResourceDownloader.java
+++ b/dsl/src/main/java/org/cloudifysource/dsl/internal/tools/download/ResourceDownloader.java
@@ -362,7 +362,12 @@ public class ResourceDownloader {
 				throw new ResourceDownloadException("Invalid resource URL: " + url.toString());
 			}
 			final URLConnection connection = url.openConnection();
-			if (this.userName != null || this.password != null) {
+			if(url.getUserInfo() != null) {
+                
+                String basicAuth = "Basic " + new String(new Base64().encode(url.getUserInfo().getBytes()));
+                connection.setRequestProperty("Authorization", basicAuth);
+                
+            }else if (this.userName != null || this.password != null) {
 				logger.fine("Setting connection credentials");
 				String up = this.userName + ":" + this.password;
 				String encoding = new String(


### PR DESCRIPTION
Allows for URL's like http:://username:password@www.somedomain.com/MyWar.war .

This is needed for recipes like Tomcat to provide a username and password for the war url. 
